### PR TITLE
Feature/1 common api response

### DIFF
--- a/src/main/java/ita/growin/global/exception/BusinessException.java
+++ b/src/main/java/ita/growin/global/exception/BusinessException.java
@@ -1,0 +1,16 @@
+package ita.growin.global.exception;
+
+import ita.growin.global.exception.errorcode.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public static BusinessException of(ErrorCode errorCode) {
+        return new BusinessException(errorCode);
+    }
+}

--- a/src/main/java/ita/growin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ita/growin/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package ita.growin.global.exception;
+
+import ita.growin.global.exception.errorcode.CommonErrorCode;
+import ita.growin.global.exception.errorcode.ErrorCode;
+import ita.growin.global.response.APIResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 에러 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<APIResponse<Void>> handleBusinessException(BusinessException exception) {
+        log.error(exception.getMessage());
+
+        return ResponseEntity.status(exception.getErrorCode().getHttpStatus().value())
+                .body(APIResponse.businessError(exception.getErrorCode()));
+    }
+
+    // NOT_FOUND 에러 처리
+    @ExceptionHandler({NoSuchElementException.class, NoResourceFoundException.class})
+    public ResponseEntity<APIResponse<Void>> handle404Exception(
+            RuntimeException exception, HttpServletRequest request) {
+        if (request.getRequestURI().endsWith(".ico")) return null; // 불필요한 리소스 요청은 무시
+
+        ErrorCode errorCode = CommonErrorCode.NOT_FOUND;
+
+        log.error(errorCode.getMessage(), exception);
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(APIResponse.commonError(errorCode));
+    }
+
+    // BAD_REQUEST 에러 처리
+    @ExceptionHandler({
+        IllegalArgumentException.class,
+        IllegalStateException.class,
+        MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<APIResponse<Void>> handle400Exception(RuntimeException exception) {
+        log.error(exception.getMessage(), exception);
+
+        ErrorCode errorCode = CommonErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(APIResponse.commonError(errorCode));
+    }
+
+    // 공통 에러 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<APIResponse<Void>> handle500Exception(Exception exception) {
+        log.error(exception.getMessage(), exception);
+
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(APIResponse.commonError(errorCode));
+    }
+}

--- a/src/main/java/ita/growin/global/exception/errorcode/BusinessErrorCode.java
+++ b/src/main/java/ita/growin/global/exception/errorcode/BusinessErrorCode.java
@@ -1,0 +1,21 @@
+package ita.growin.global.exception.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BusinessErrorCode implements ErrorCode {
+    TEST(HttpStatus.INTERNAL_SERVER_ERROR, "TEST_ERROR_CODE", "테스트 에러코드입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "멤버를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    BusinessErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/ita/growin/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/ita/growin/global/exception/errorcode/CommonErrorCode.java
@@ -1,0 +1,24 @@
+package ita.growin.global.exception.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommonErrorCode implements ErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "400", "잘못된 입력값입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "403", "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "404", "존재하지 않는 리소스입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버 에러가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    CommonErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/ita/growin/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/ita/growin/global/exception/errorcode/ErrorCode.java
@@ -1,0 +1,12 @@
+package ita.growin.global.exception.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getHttpStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/ita/growin/global/health/controller/HealthCheckController.java
+++ b/src/main/java/ita/growin/global/health/controller/HealthCheckController.java
@@ -1,0 +1,26 @@
+package ita.growin.global.health.controller;
+
+import ita.growin.global.exception.BusinessException;
+import ita.growin.global.exception.errorcode.BusinessErrorCode;
+import ita.growin.global.response.APIResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health")
+    public APIResponse<?> test() {
+        return APIResponse.success("test");
+    }
+
+    @GetMapping("/business-error")
+    public APIResponse<?> businessError() {
+        throw BusinessException.of(BusinessErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @GetMapping("/common-error")
+    public APIResponse<?> commonError() throws Exception {
+        throw new Exception("INTERNAL_SERVER_ERROR");
+    }
+}

--- a/src/main/java/ita/growin/global/response/APIResponse.java
+++ b/src/main/java/ita/growin/global/response/APIResponse.java
@@ -1,0 +1,44 @@
+package ita.growin.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import ita.growin.global.exception.errorcode.ErrorCode;
+import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record APIResponse<T>(
+        int status,
+        String code, // 비즈니스 에러일 때만 값 존재
+        String message,
+        LocalDateTime timestamp,
+        T data // 성공일 때만 값 존재
+        ) {
+
+    private static final String SUCCESS_MESSAGE = "요청이 성공적으로 처리되었습니다.";
+
+    // 성공응답
+    public static <T> APIResponse<T> success(T data) {
+        return new APIResponse<>(
+                HttpStatus.OK.value(), null, SUCCESS_MESSAGE, LocalDateTime.now(), data);
+    }
+
+    // 실패응답 (공통)
+    public static <T> APIResponse<T> commonError(ErrorCode errorCode) {
+        return new APIResponse<>(
+                errorCode.getHttpStatus().value(),
+                null,
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                null);
+    }
+
+    // 실패응답 (비즈니스)
+    public static <T> APIResponse<T> businessError(ErrorCode errorCode) {
+        return new APIResponse<>(
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                null);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=growin

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: growin

--- a/src/test/java/ita/growin/response/ResponseTest.java
+++ b/src/test/java/ita/growin/response/ResponseTest.java
@@ -1,0 +1,63 @@
+package ita.growin.response;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ita.growin.global.exception.errorcode.BusinessErrorCode;
+import ita.growin.global.exception.errorcode.CommonErrorCode;
+import ita.growin.global.exception.errorcode.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ResponseTest {
+
+    private static final String SUCCESS_MESSAGE = "요청이 성공적으로 처리되었습니다.";
+    private static final ErrorCode BUSINESS_ERRORCODE = BusinessErrorCode.MEMBER_NOT_FOUND;
+
+    @Autowired MockMvc mockMvc;
+
+    @Test
+    @DisplayName("응답 성공 시, APIResponse.success()의 리턴형식을 준수합니다.")
+    public void success_response() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").doesNotExist())
+                .andExpect(jsonPath("$.message").value(SUCCESS_MESSAGE))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.data").exists());
+    }
+
+    @Test
+    @DisplayName("Business 에러 발생 시, APIResponse.businessError()의 리턴형식을 준수합니다.")
+    public void business_error_response() throws Exception {
+        mockMvc.perform(get("/business-error"))
+                .andExpect(result -> assertNotEquals(200, result.getResponse().getStatus()))
+                .andExpect(jsonPath("$.status").value(BUSINESS_ERRORCODE.getHttpStatus().value()))
+                .andExpect(jsonPath("$.code").value(BUSINESS_ERRORCODE.getCode()))
+                .andExpect(jsonPath("$.message").value(BUSINESS_ERRORCODE.getMessage()))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DisplayName("Common 에러 발생 시, APIResponse.commonError()의 리턴형식을 준수합니다.")
+    public void commonError() throws Exception {
+        mockMvc.perform(get("/common-error"))
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.code").doesNotExist())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage()))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+}


### PR DESCRIPTION
## 📝 상세 내용
<!-- 어떤 변경이 이루어졌는지 간단히 설명해주세요 -->
### 응답 형식 통일 (APIResponse)
- [성공 응답]
```json
{
  "status": 200,
  "message": "요청이 성공적으로 처리되었습니다.",
  "timestamp": "2025-09-19T12:00:00",
  "data": {
    "id": 1,
    "name": "홍길동"
  }
}
```

- [실패 응답 - Business Error]
```json
{
  "status": 404,
  "code": "USER_NOT_FOUND",
  "message": "사용자를 찾을 수 없습니다.",
  "timestamp": "2025-09-19T15:00:05"
	}
```
- 프론트의 에러 핸들링을 위한 `code`필드 추가

- [실패 응답 - Common Error]
```json
{
  "status": 404,
  "message": "리소스를 찾을 수 없습니다.",
  "timestamp": "2025-09-19T12:00:05"
}
```
- 백 서버에서 미처 catch하지 못한 에러에 대해 발생하는 에러 형식
- Business Error와 다른점 : `code`필드의 유무

### ErrorCode 생성
- ErrorCode.java
```java
public interface ErrorCode {

    HttpStatus getHttpStatus();

    String getCode();

    String getMessage();
}
```
- 에러 코드 인터페이스화 -> 개발이 진행될수록 길어지는 ErrorCode (enum타입)을 방지하기 위함
- `ErrorCode`를 implements한 ErrorCode를 통해 도메인 별 에러코드 관리 용이
ex) `MemberErrorCode`, `AuthErrorCode`. `CommonErrorCode` 등...
```java
@Getter
public enum CommonErrorCode implements ErrorCode {
    BAD_REQUEST(HttpStatus.BAD_REQUEST, "400", "잘못된 입력값입니다."),
    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "인증이 필요합니다."),
    FORBIDDEN(HttpStatus.FORBIDDEN, "403", "접근 권한이 없습니다."),
    NOT_FOUND(HttpStatus.NOT_FOUND, "404", "존재하지 않는 리소스입니다."),
    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버 에러가 발생했습니다."),
    ;

    private final HttpStatus httpStatus;
    private final String code;
    private final String message;

    CommonErrorCode(HttpStatus httpStatus, String code, String message) {
        this.httpStatus = httpStatus;
        this.code = code;
        this.message = message;
    }
}
```
- 현재는 개발이 진행되지 않아 `CommonErrorCode`, `BusinessErrorCode`만 생성
- 후에 `BusinessErrorCode`를 분리하여 도메인 별 ErrorCode 구현체 생성 예정

### `GlobalExceptionHandler`생성

### HealthCheck 및 테스트를 위한 `HealthCehckController` 생성

### 응답형식에 대한 Test 코드 작성 완료

---

## 🔗 관련 이슈
- Closes #1 

---

## 💬리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요 -->
- 기존의 `ErrorCode`를 enum처리하지 않고 인터페이스로 선언하는게 괜찮은지
- 성공·실패 응답이 필요한 정보를 다 담고 있는지
- pr 템플릿에 불필요한 항목들은 없는지
---